### PR TITLE
Feature: Cannot add pages/sections with dupe names

### DIFF
--- a/modules/page.py
+++ b/modules/page.py
@@ -11,6 +11,12 @@ from PySide6.QtGui import *
 def add_page(editor):
     title, accept = QInputDialog.getText(editor, 'New Page Title', 'Enter title of new page: ')
     if accept:
+        for p in range(len(editor.notebook.page)):
+            if title == editor.notebook.page[p].title:
+                error = QMessageBox(editor)
+                error.setText("A Page with that name already exists.")
+                error.show()
+                return
         build_page(editor, title)
         editor.notebook.page.append(Page(title))
         add_page_change(editor)
@@ -121,6 +127,12 @@ def page_menu(editor, event):
 def rename_page(editor):
     title, accept = QInputDialog.getText(editor, 'Change Page Title', 'Enter new title of page: ')
     if accept:
+        for p in range(len(editor.notebook.page)):
+            if title == editor.notebook.page[p].title:
+                error = QMessageBox(editor)
+                error.setText("A Page with that name already exists.")
+                error.show()
+                return
         for p in range(len(editor.notebook.page)):
             if editor.focusWidget().objectName() == editor.notebook.page[p].title:
                 editor.notebook.page[p].title = title

--- a/modules/section.py
+++ b/modules/section.py
@@ -9,6 +9,12 @@ from PySide6.QtGui import *
 def add_section(editor):
     title, accept = QInputDialog.getText(editor, 'New Section Title', 'Enter title of new section: ')
     if accept:
+        for s in range(len(editor.notebook.page[editor.page].section)):
+            if title == editor.notebook.page[editor.page].section[s].title:
+                error = QMessageBox(editor)
+                error.setText("A section with that name already exists.")
+                error.show()
+                return
         build_section(editor, title)
         editor.notebook.page[editor.page].section.append(Section(title))
         editor.section += 1
@@ -79,6 +85,12 @@ def section_menu(editor, event):
 def rename_section(editor):
     title, accept = QInputDialog.getText(editor, 'Change Section Title', 'Enter new title of section: ')
     if accept:
+        for s in range(len(editor.notebook.page[editor.page].section)):
+            if title == editor.notebook.page[editor.page].section[s].title:
+                error = QMessageBox(editor)
+                error.setText("A section with that name already exists.")
+                error.show()
+                return
         for s in range(len(editor.notebook.page[editor.page].section)):
             if editor.focusWidget().objectName() == editor.notebook.page[editor.page].section[s].title:
                 editor.notebook.page[editor.page].section[s].title = title


### PR DESCRIPTION
Added check to add/rename page and section to ensure that you cannot have pages or sections with duplicate names, as names are used to determine which widget to delete, rename, etc.