### PR TITLE
Fixed section/page bug on Mac

### DIFF
--- a/modules/build_ui.py
+++ b/modules/build_ui.py
@@ -5,7 +5,6 @@ from modules.section import add_section
 from modules.object import add_object,add_plugin_object
 from modules.plugins import get_plugins
 
-from PyQt6 import *
 from PySide6.QtCore import *
 from PySide6.QtGui import *
 from PySide6.QtWidgets import *

--- a/modules/load.py
+++ b/modules/load.py
@@ -51,6 +51,8 @@ def build(editor):
 
     # Initialize the autosaver
     editor.autosaver = Autosaver(editor, editor.notebook)
+    editor.object = []
+    editor.selected = None
 
     if len(editor.notebook.page) > 0:   # If pages exist
 

--- a/modules/page.py
+++ b/modules/page.py
@@ -29,7 +29,7 @@ def add_page(editor):
 # Case 2: When new Page is created by user
 def build_page(editor, title):
     page = QPushButton(title)
-    page.mousePressEvent = lambda x: page_menu(editor, x)
+    page.mousePressEvent = lambda x: page_menu(editor, page, x)
     page.setObjectName(title)
     editor.pages.addWidget(page)
 
@@ -106,8 +106,8 @@ def add_page_change(editor):
     editor.autosaver.onChangeMade()
 
 # Handles Page Clicks
-def page_menu(editor, event):
-
+def page_menu(editor, page, event):
+    page.setFocus()
     # Change Page
     if event.buttons() == Qt.LeftButton:
         change_page(editor)

--- a/modules/section.py
+++ b/modules/section.py
@@ -30,14 +30,13 @@ def add_section(editor):
 
 def build_section(editor, title):
     section = QPushButton(title)
-    section.mousePressEvent = lambda x: section_menu(editor, x)
+    section.mousePressEvent = lambda x: section_menu(editor, section, x)
     section.setObjectName(title)
     editor.sections_frame.setFixedWidth(0)
     editor.sections.addWidget(section)
 
-def change_section(editor):
+def change_section(editor, section):
     store_section(editor)
-
     for o in range(len(editor.object)):
         editor.object[o].deleteLater()
     editor.object.clear()
@@ -47,7 +46,6 @@ def change_section(editor):
         if(editor.focusWidget().objectName() == editor.notebook.page[editor.page].section[s].title):
             editor.sections.itemAt(s).widget().setStyleSheet("background-color: #c2c2c2")
             editor.section = s
-
     for o in range(len(editor.notebook.page[editor.page].section[editor.section].object)):
         params = editor.notebook.page[editor.page].section[editor.section].object[o]
         build_object(editor, params)
@@ -70,10 +68,11 @@ def store_section(editor):
                     editor.notebook.page[editor.page].section[editor.section].object[o].w = editor.object[o].geometry().width()
                     editor.notebook.page[editor.page].section[editor.section].object[o].h = editor.object[o].geometry().height()
 
-def section_menu(editor, event):
+def section_menu(editor, section, event):
+    section.setFocus()
     # Change Page
     if event.buttons() == Qt.LeftButton:
-        change_section(editor)
+        change_section(editor, section)
 
     # Open Context Menu
     if event.buttons() == Qt.RightButton:

--- a/screens/editor.py
+++ b/screens/editor.py
@@ -3,7 +3,6 @@ from modules.build_ui import *
 from modules.load import new
 from modules.save import Autosaver
 
-from PyQt6 import *
 from PySide6.QtCore import *
 from PySide6.QtGui import *
 from PySide6.QtWidgets import *


### PR DESCRIPTION
- Removed PyQt6 import (not needed)
- Fixed issue with loading a Notebook while Notebook is already loaded
- Assuming it's a Mac issue, focusWidget() does not update when a QPushButton is clicked. SetFocus() was added to the MousePressEvents on sections/pages to resolve this issue.