### PR TITLE
Table cell resize

### DIFF
--- a/Widgets/Table.py
+++ b/Widgets/Table.py
@@ -5,14 +5,24 @@ from PySide6.QtWidgets import *
 class TableWidget(QWidget):
     def __init__(self, x, y, w, h, rows, cols):
         super(TableWidget, self).__init__()
-
+        
         # The actual table widget
         self.table = QTableWidget(rows, cols, self)
         # Hide the horizontal and vertical headers
         self.table.horizontalHeader().setVisible(False)
         self.table.verticalHeader().setVisible(False)
-        self.setStyleSheet("QWidget {border: 1px solid black;}")
 
+        # Get the default table border color from the palette
+        table_border_color = self.palette().color(QPalette.Window)
+
+        # Add a custom border on the top of the widget
+        self.table.setStyleSheet(f"QTableView {{border: 1px solid {table_border_color.name()};}}")
+           
+        # Make the cells resizable
+        self.table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)  
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+
+        
         self.setGeometry(x, y, w, h)
         self.table.setGeometry(0, 0, w, h)
         self.resize(w, h)

--- a/Widgets/Table.py
+++ b/Widgets/Table.py
@@ -11,6 +11,8 @@ class TableWidget(QWidget):
         # Hide the horizontal and vertical headers
         self.table.horizontalHeader().setVisible(False)
         self.table.verticalHeader().setVisible(False)
+        self.setStyleSheet("QWidget {border: 1px solid black;}")
+
         self.setGeometry(x, y, w, h)
         self.table.setGeometry(0, 0, w, h)
         self.resize(w, h)


### PR DESCRIPTION
Fixed Border issue with tables
made cells resizable 

Note: seems like the table is off by a few pixels inside the draggable widget because when I tried to set the border color for the table cells left and top borders were still white probably because the draggable object's border was on top of it (not sure).